### PR TITLE
Fix SetPlayerDuty

### DIFF
--- a/modules/framework/es_extended/server.lua
+++ b/modules/framework/es_extended/server.lua
@@ -330,7 +330,7 @@ Framework.SetPlayerDuty = function(src, status)
     local xPlayer = Framework.GetPlayer(src)
     if not xPlayer then return false end
     local job = xPlayer.getJob()
-    if not job.onDuty then return false end
+    if job.jobName == 'unemployed' then return false end
     xPlayer.setJob(job.name, job.grade, status)
     return true
 end


### PR DESCRIPTION
If you were offDuty you were not able to go on duty with the function instead of checking for their duty I am checking weather or not they have a job in the first place. (unemployed), I have tested and ensure this works properly as intended regarding documentation

## Pull Request Checklist

- [ X] PR is targeting the `dev` branch
- [ X] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [ X] My code follows the project’s style guidelines
- [ X] I have tested my changes and ensured they work as expected
- [ X] Relevant documentation/comments have been added or updated
- [ X] Any dependent changes have been merged

### Resource Relevance and Usage
- [ ] Resource is active on 100+ servers, OR
- [ ] Resource has a verifiable dependency on community_bridge, OR
- [ ] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [ ] No breaking changes introduced, OR
- [ ] If deprecating: 2-4 month grace period provided
- [ ] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [ ] At least one usage example included.
- [ ] IntelliSense-style comments added.
- [ ] Unit test coverage provided

## Description

<!-- Please include a summary of the changes and the purpose of this PR -->

## Related Issues

<!-- If this PR addresses any issues, please link them here using "Fixes #issue_number" -->

## Testing Steps

<!-- Describe how the changes were tested and how reviewers can verify them -->

## Additional Notes

<!-- Add any other relevant information or context here -->