### PR TITLE
Add deprecated args field to Point.Register

### DIFF
--- a/lib/points/client/points.lua
+++ b/lib/points/client/points.lua
@@ -99,6 +99,7 @@ function Point.Register(id, target, distance, args, _onEnter, _onExit, _onUpdate
     self.onExit = _onExit or function() end
     self.onUpdate = _onUpdate or function() end
     self.inside = false -- Track if player is inside
+    self.args = args or {} --DEPRICATED 2025-09-10
     local grid = Grid.GetCellByCoords(coords)
     grid[id] = self
     Point.All[id] = self


### PR DESCRIPTION
This pull request introduces a minor change to the `Point.Register` function in `lib/points/client/points.lua`, adding a deprecated field for backward compatibility.

* Added the `self.args` property to `Point.Register`, marking it as deprecated with a sunset date of 2025-09-10 to signal future removal.Introduces a self.args field to the Point.Register function, marked as deprecated for future removal 2025-09-10. This change preserves compatibility for code relying on the args property.

## Pull Request Checklist

- [ ] PR is targeting the `dev` branch
- [ ] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [ ] My code follows the project’s style guidelines
- [ ] I have tested my changes and ensured they work as expected
- [ ] Relevant documentation/comments have been added or updated
- [ ] Any dependent changes have been merged

### Resource Relevance and Usage
- [ ] Resource is active on 100+ servers, OR
- [ ] Resource has a verifiable dependency on community_bridge, OR
- [ ] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [ ] No breaking changes introduced, OR
- [ ] If deprecating: 2-4 month grace period provided
- [ ] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [ ] At least one usage example included.
- [ ] IntelliSense-style comments added.
- [ ] Unit test coverage provided

## Description

<!-- Please include a summary of the changes and the purpose of this PR -->

## Related Issues

<!-- If this PR addresses any issues, please link them here using "Fixes #issue_number" -->

## Testing Steps

<!-- Describe how the changes were tested and how reviewers can verify them -->

## Additional Notes

<!-- Add any other relevant information or context here -->