### PR TITLE
FIX - QB-Core - Framework/Inventory - Item properties fix

### DIFF
--- a/modules/framework/qb-core/client.lua
+++ b/modules/framework/qb-core/client.lua
@@ -184,7 +184,7 @@ Framework.GetItemCount = function(item)
     local count = 0
     for _, v in pairs(frameworkInv) do
         if v.name == item then
-            count = count + v.amount
+            count = count + (v.amount or v.count)
         end
     end
     return count
@@ -199,7 +199,7 @@ Framework.GetPlayerInventory = function()
         table.insert(items, {
             name = v.name,
             label = v.label,
-            count = v.amount,
+            count = v.amount or v.count,
             slot = v.slot,
             metadata = v.info,
             stack = v.unique,

--- a/modules/framework/qb-core/server.lua
+++ b/modules/framework/qb-core/server.lua
@@ -100,7 +100,7 @@ Framework.GetItem = function(src, item, metadata)
         if v.name == item and (not metadata or v.info == metadata) then
             table.insert(repackedTable, {
                 name = v.name,
-                count = v.amount,
+                count = v.amount or v.count,
                 metadata = v.info,
                 slot = v.slot,
             })
@@ -141,7 +141,7 @@ Framework.GetItemCount = function(src, item, metadata)
     local count = 0
     for _, v in pairs(playerInventory) do
         if v.name == item and (not metadata or v.info == metadata) then
-            count = count + v.amount
+            count = count + (v.amount or v.count)
         end
     end
     return count
@@ -170,7 +170,7 @@ Framework.GetPlayerInventory = function(src)
     for _, v in pairs(playerInventory) do
         table.insert(repackedTable, {
             name = v.name,
-            count = v.amount,
+            count = v.amount or v.count,
             metadata = v.info,
             slot = v.slot,
         })
@@ -206,7 +206,7 @@ Framework.GetItemBySlot = function(src, slot)
                 name = v.name,
                 label = v.label,
                 weight = v.weight,
-                count = v.amount,
+                count = v.amount or v.count,
                 metadata = v.info,
                 slot = v.slot,
                 stack = v.unique or false,


### PR DESCRIPTION
## Description
QB-Core Framework.
Some inventories has item property `count` instead of `amount`. +/- Added fallback to `count` if `amount` doesn't exists.

## Related Issues
item property: `count`
error caused on qb-core with ox_inventory (well , ox_inventory doesn't support out-of-the-box the qb-core framework, but not all inventories has amount property, some has count)